### PR TITLE
Use node 16 and python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM node:12-alpine
-RUN apk --no-cache add --virtual builds-deps build-base python
+FROM node:16-alpine
+RUN apk --no-cache add --virtual builds-deps build-base python2
 CMD [ "node" ]


### PR DESCRIPTION
I need this Dockerfile with node 16. I'm not sure how to test this for my own purpose, but at least it builds with node 16 and python2.